### PR TITLE
layers: Bump to use kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_PATTERN_elm-binary-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_elm-binary-layer = "7"
 
 LAYERDEPENDS_elm-binary-layer = ""
-LAYERSERIES_COMPAT_elm-binary-layer = "honister"
+LAYERSERIES_COMPAT_elm-binary-layer = "kirkstone"


### PR DESCRIPTION
its not going to be backward ABI compatible with honister due to variable renaming.

Signed-off-by: Khem Raj <raj.khem@gmail.com>